### PR TITLE
DEVOPS-4187 Enabled ELB Healthcheck on the autoscaling group

### DIFF
--- a/Q4CDN/q4cdn-ngxinx-private-template.json
+++ b/Q4CDN/q4cdn-ngxinx-private-template.json
@@ -135,6 +135,8 @@
         "MinSize": "1",
         "MaxSize": "4",
         "DesiredCapacity": "1",
+        "HealthCheckType": "ELB",
+        "HealthCheckGracePeriod": "60",
         "LoadBalancerNames": [ { "Ref": "ElasticLoadBalancer" } ]
       }
     },


### PR DESCRIPTION
This is required in order for the Autoscaling group to use ELB healthcheck, by default it uses EC2 healthcheck which does NOT replace an instance if nginx service is stopped. Tested in Ohio.