### PR TITLE
DEVOPS-4216 Added encrypted AMI for AWS DR us-east-2.

### DIFF
--- a/Q4CDN/q4cdn-ngxinx-private-template.json
+++ b/Q4CDN/q4cdn-ngxinx-private-template.json
@@ -107,7 +107,7 @@
   "Mappings": {
     "EncryptedUbuntuAMI": {
       "us-east-1": { "Stage": "ami-7d607006", "DR": "ami-d81606a3"},
-      "us-east-2": { "Stage": "ami-af6d4fca" },
+      "us-east-2": { "Stage": "ami-af6d4fca", "DR": "ami-f586a490" },
       "us-west-2": { "DR": "ami-726d990a" },
       "ca-central-1": { "Stage": "ami-0009b764" }
     }


### PR DESCRIPTION
Needed AMI ID for DR Ohio, deployed the environment in Ohio already.